### PR TITLE
Remove duplicate MetalDetector and add KorraContexts plugin

### DIFF
--- a/forum.json
+++ b/forum.json
@@ -3016,19 +3016,6 @@
         "max_pk_version": ""
     },
     {
-        "name": "MetalDetector",
-        "author": "Unprankable",
-        "category": "metalbending",
-        "last_update": "Apr 10, 2025",
-        "latest_version": "1.2",
-        "download_url": "https://projectkorra.com/forum/resources/metaldetector-1-2.505/download",
-        "source_url": "https://projectkorra.com/forum/resources/metaldetector-1-2.505",
-        "min_mc_version": "",
-        "max_mc_version": "",
-        "min_pk_version": "1.11.2",
-        "max_pk_version": ""
-    },
-    {
         "name": "Soar",
         "author": "Nysseus",
         "category": "airbending",

--- a/github.json
+++ b/github.json
@@ -700,5 +700,18 @@
         "max_mc_version": "",
         "min_pk_version": "",
         "max_pk_version": ""
+    },
+    {
+        "name": "KorraContexts",
+        "author": "Unprankable",
+        "category": "Side plugin",
+        "last_update": "Apr 20, 2026",
+        "latest_version": "1.0.4",
+        "download_url": "https://github.com/PrestonCurtis1/KorraContexts/releases",
+        "source_url": "https://github.com/PrestonCurtis1/KorraContexts",
+        "min_mc_version": "",
+        "max_mc_version": "",
+        "min_pk_version": "",
+        "max_pk_version": ""
     }
 ]


### PR DESCRIPTION
This pull request updates the plugin listings by removing an outdated plugin and adding a new one. The main changes are:

**Plugin List Updates:**

* Removed the `MetalDetector` plugin entry from `forum.json`, because it is a duplicate and will no longer be supported
* Added the `KorraContexts` plugin entry to `github.json`, including its metadata and relevant URLs.